### PR TITLE
Removing whitelist (closes #50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,5 @@
   "scripts": {
     "lint": "eslint .",
     "test": "set NODE_ENV=test && \"./node_modules/.bin/mocha\" unitTest.js"
-  },
-  "files": [
-    "generators/app"
-  ]
+  }
 }


### PR DESCRIPTION
Not all files went to npm because there was a whitelist in the package.json.

Removed the whitelist now all files go to npm

See: https://docs.npmjs.com/files/package.json#files