### PR TITLE
Added whitelist with needed files (closes #50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "test": "set NODE_ENV=test && \"./node_modules/.bin/mocha\" unitTest.js"
   },
   "files": [
-    "generators/app"
+    "generators/app",
+    "sampleApp",
+    "rooseveltDefaults.json"
   ]
 }


### PR DESCRIPTION
Added whitelist back in, we can't use take all files because then the `.gitignore` file needed for our sample app is ignored on the `npm publish`.